### PR TITLE
Remove keys arg that was hiding most data

### DIFF
--- a/notebooks/var-benchmark/main.ipynb
+++ b/notebooks/var-benchmark/main.ipynb
@@ -46,9 +46,7 @@
    "outputs": [],
    "source": [
     "# Load risk dataset\n",
-    "dataset = session.read_parquet(\n",
-    "    \"dataset.parquet\", keys=[\"index\"], partitioning=\"hash32(index)\"\n",
-    ")"
+    "dataset = session.read_parquet(\"dataset.parquet\", partitioning=\"hash32(str0)\")"
    ]
   },
   {


### PR DESCRIPTION
The VaR aggregation benchmark was declaring a wrong key that hides most of the data (10.000 facts against actually 1.7M facts).

This was however done after the benchmark publication, and doesn't change the published numbers.